### PR TITLE
Speed up the isObject function

### DIFF
--- a/src/components/Results/Hit.js
+++ b/src/components/Results/Hit.js
@@ -95,14 +95,7 @@ const ObjectValue = ({ value }) => {
   )
 }
 
-const isObject = (value) => {
-  try {
-    const data = JSON.parse(value)
-    return data.constructor.name === 'Object'
-  } catch (err) {
-    return false
-  }
-}
+const isObject = (value) => value.trim().match(/^{(.*?)}$/)
 
 const FieldValue = ({ value, hit, objectKey }) => {
   if (isObject(value)) return <ObjectValue value={value} />


### PR DESCRIPTION
The `isObject` function is slowing down the page rendering, so I decided to simplify it by removing the parsing step and replaced it with a simple check of the first and last character, not correct but much faster. MeiliSearch will probably never return invalid JSON objects anyway 😄

There also is the `emotion/css` module that slows down the page rendering.

I also learned that a `yarn build` is much faster as it generates an optimized build 🎉
```bash
yarn build
cd build
python3 -m http.server 8000
```

It could be great if you could make the `yarn build` command to be able to run with the server running on `127.0.0.1:7700` and add these three commands in the readme, it would help others run the server in production and avoid performances issues. 😄