### PR TITLE
Add type attribute to component Input

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -71,7 +71,7 @@ const InputContainer = styled.div`
 const Input = ({ icon, ref, clear, type, value, ...props }) => (
   <InputContainer ref={ref}>
     {icon}
-    <InputField $hasIcon={icon} value={value} {...props} />
+    <InputField $hasIcon={icon} value={value} type={type} {...props} />
     {type === 'search' && (
       <ClearButton
         onClick={() => clear()}


### PR DESCRIPTION
The attribute `type` does not spread into the final HTML input element in the component `Input`

- Add type attribute to the `InputField` in the component `Input` 

:tada: