### PR TITLE
Use RELEASE_DRAFTER_TOKEN secret var

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           config-name: release-draft-template.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DRAFTER_TOKEN }}


### PR DESCRIPTION
This PR makes use the [meili-bot](https://github.com/meili-bot) credentials.

This will prevent from some failures. Why?

The release drafter is GitHub automation. So the author of the release is an automation.
Your [release push](https://github.com/meilisearch/mini-dashboard/blob/main/.github/workflows/publish-build.yml) is a GitHub automation.
And a GitHub automation cannot trigger another GitHub automation.

It means you cannot trigger your CI push by creating a release where the author is an automation. That's why we use the meili-bot credentials, so that a GitHub user creates the release draft. So the creator of the release is meili-bot and not an automation.

Sorry, not obvious, but we already had troubles with this 😅 