### PR TITLE
Update instant meilisearch version & fix check is server healthy

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.4",
   "private": true,
   "dependencies": {
-    "@meilisearch/instant-meilisearch": "^0.5.0",
+    "@meilisearch/instant-meilisearch": "^0.5.6",
     "@styled-system/should-forward-prop": "^5.1.5",
     "babel-loader": "8.1.0",
     "color": "^3.1.3",

--- a/src/App.js
+++ b/src/App.js
@@ -132,11 +132,7 @@ const App = () => {
         if (err.errorCode === 'missing_authorization_header') {
           setRequireApiKeyToWork(true)
         } else {
-          try {
-            await client.MeiliSearchClient.isHealthy()
-          } catch (e) {
-            setIsMeiliSearchRunning(false)
-          }
+          setIsMeiliSearchRunning(await client.MeiliSearchClient.isHealthy())
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,12 +1774,12 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
-"@meilisearch/instant-meilisearch@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@meilisearch/instant-meilisearch/-/instant-meilisearch-0.5.0.tgz#dbad2ff0f7e6ced2cb8ecc176e7b7e82ee34f6b8"
-  integrity sha512-f2pocX10r8MR+dNr4pN7AoUjjGV30hZqBojGiRZRaVkcSm9+TPJ6fDljo1mp6CPMIi6ja3pC/ALSEpAgPINAWg==
+"@meilisearch/instant-meilisearch@^0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@meilisearch/instant-meilisearch/-/instant-meilisearch-0.5.6.tgz#ab69d635ed115acf4c578310d0b86dc12449e06f"
+  integrity sha512-R3WJ4HTigUuF30kaeYGtDqRA9hiKu74EhoUGjR+XaH1HNcdqF7A/KOAIHJ2dpVsbTCWQcFDchZAc/OIAOK7aMA==
   dependencies:
-    meilisearch "^0.18.1"
+    meilisearch "^0.21.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -10087,10 +10087,10 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-meilisearch@^0.18.1:
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.18.2.tgz#e26d33a4bf163b2d96b14015063ec5979a004793"
-  integrity sha512-L65u+yNNtIyai3V1XB7BOq+fAt6MzB2KtsqvaW6GNahPtWCZF9SKvWOl6fjhzH3KOHDyT++A65UoYJP4J7vnVA==
+meilisearch@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.21.0.tgz#440f686803314444eb97a821ec143c8d01b33f64"
+  integrity sha512-LBLePf0lgTEHX2vIkdC9AH2a7XITssKTYHBaUjuCnE394Q6ntLmvpYWjGCfv6fqGTv9q9vkfy1kdfYrqL9a2XA==
   dependencies:
     cross-fetch "^3.1.4"
 


### PR DESCRIPTION
- Update Instant MeiliSearch version
- Fix to display the message telling that MeiliSearch isn't running, which was introduced by the upgrade above (the method `isHealthy` returns false instead of throwing)