### PR TITLE
Add webp support for images

### DIFF
--- a/src/components/Results/InfiniteHits.js
+++ b/src/components/Results/InfiniteHits.js
@@ -22,7 +22,7 @@ const findImageKey = (array) => {
   const imageKey = array.find(
     (elem) =>
       typeof elem[1] === 'string' &&
-      elem[1].match(/^(https|http):\/\/.*(jpe?g|png|gif)(\?.*)?$/g)
+      elem[1].match(/^(https|http):\/\/.*(jpe?g|png|gif|webp)(\?.*)?$/g)
   )
   return imageKey?.[0]
 }


### PR DESCRIPTION
This PR allows webp images to appear as posters, instead of displaying a placeholder.
See #149