### PR TITLE
Run most tests without needing an api key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,10 +80,12 @@ jobs:
         run: yarn
       - name: Test
         uses: cypress-io/github-action@v2
+        env:
+          CYPRESS_host: http://meilisearch:7700
         with:
           start: yarn start:ci
           wait-on: 'http://0.0.0.0:3000'
-          command: yarn cy:run:test-no-api-key
+          command: yarn cy:run
           config-file: cypress.json
       - uses: actions/upload-artifact@v1
         if: failure()
@@ -126,7 +128,7 @@ jobs:
         with:
           start: yarn start:ci
           wait-on: 'http://0.0.0.0:3000'
-          command: yarn cy:run
+          command: yarn cy:run:test-api-key-required
           config-file: cypress.json
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/cypress/integration/test-interface.js
+++ b/cypress/integration/test-interface.js
@@ -1,5 +1,4 @@
 const WAITING_TIME = Cypress.env('waitingTime')
-const API_KEY = Cypress.env('apiKey')
 
 describe(`Test interface`, () => {
   before(() => {
@@ -22,12 +21,7 @@ describe(`Test interface`, () => {
 
   beforeEach(() => {
     cy.visit('/')
-    // Fill the API key
-    cy.get('div[aria-label=ask-for-api-key]').within(() => {
-      cy.get('input[name="apiKey"]').clear().type(API_KEY)
-      cy.get('button').contains('Go').click()
-      cy.wait(WAITING_TIME)
-    })
+    cy.wait(WAITING_TIME)
   })
 
   it('Should open the help center on click on the "?" button', () => {

--- a/cypress/integration/test-no-api-key-required.js
+++ b/cypress/integration/test-no-api-key-required.js
@@ -1,5 +1,9 @@
+const WAITING_TIME = Cypress.env('waitingTime')
+
 describe(`Test no API key required`, () => {
   before(() => {
+    cy.deleteAllIndexes()
+    cy.wait(WAITING_TIME)
     cy.visit('/')
   })
 

--- a/cypress/integration/test-search.js
+++ b/cypress/integration/test-search.js
@@ -1,5 +1,4 @@
 const WAITING_TIME = Cypress.env('waitingTime')
-const API_KEY = Cypress.env('apiKey')
 
 describe(`Test search`, () => {
   before(() => {
@@ -12,17 +11,11 @@ describe(`Test search`, () => {
       cy.addDocuments('movies', movies)
       cy.wait(WAITING_TIME)
     })
-    cy.visit('/')
-    // Fill the API key
-    cy.get('div[aria-label=ask-for-api-key]').within(() => {
-      cy.get('input[name="apiKey"]').clear().type(API_KEY)
-      cy.get('button').contains('Go').click()
-      cy.wait(WAITING_TIME)
-    })
   })
 
   beforeEach(() => {
-    cy.get('input[type="search"]').clear()
+    cy.visit('/')
+    cy.wait(WAITING_TIME)
   })
 
   it('Should update the results according to the user’s search', () => {

--- a/cypress/integration/test-select-indexes.js
+++ b/cypress/integration/test-select-indexes.js
@@ -1,5 +1,4 @@
 const WAITING_TIME = Cypress.env('waitingTime')
-const API_KEY = Cypress.env('apiKey')
 
 describe(`Test indexes`, () => {
   before(() => {
@@ -32,11 +31,7 @@ describe(`Test indexes`, () => {
 
   beforeEach(() => {
     cy.visit('/')
-    cy.get('div[aria-label=ask-for-api-key]').within(() => {
-      cy.get('input[name="apiKey"]').clear().type(API_KEY)
-      cy.get('button').contains('Go').click()
-      cy.wait(WAITING_TIME)
-    })
+    cy.wait(WAITING_TIME)
   })
 
   it('Should display the first index based on localeCompare order on the uid', () => {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "build-storybook": "build-storybook -s public",
     "cy:open": "cypress open",
     "cy:run:test-no-meilisearch": "cypress run --spec 'cypress/integration/test-no-meilisearch.js'",
-    "cy:run:test-no-api-key": "cypress run --spec 'cypress/integration/test-no-api-key-required.js'",
-    "cy:run": "cypress run --config ignoreTestFiles=['**/*/test-no-meilisearch.js','test-no-api-key-required.js']",
+    "cy:run:test-api-key-required": "cypress run --spec 'cypress/integration/test-api-key-required.js'",
+    "cy:run": "cypress run --config ignoreTestFiles=['**/*/test-no-meilisearch.js','test-api-key-required.js']",
     "icons": "npx @svgr/cli --title-prop --no-dimensions --replace-attr-values \"#39486E=currentColor,#959DB3=currentColor\" -d src/components/icons src/components/icons/svg"
   },
   "browserslist": {


### PR DESCRIPTION
Most of the CI's tests where running on a Docker with an API key beeing required. 
In order to speed up the tests, some of them where moved to the Docker not needing an API key.