### PR TITLE
Fix help center cards height

### DIFF
--- a/src/components/Header/HelpCenter.js
+++ b/src/components/Header/HelpCenter.js
@@ -36,10 +36,17 @@ const StyledLink = styled(Link)`
   }
 `
 
+const Logo = styled.div`
+  height: 62px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
 const HelpCard = ({ description, title, logo, href, ...props }) => (
   <StyledLink href={href} style={{ textDecoration: 'none' }} {...props}>
     <StyledCard forwardedAs="div">
-      {logo}
+      <Logo>{logo}</Logo>
       <Typography variant="typo4" color="gray.0" my={1}>
         {title}
       </Typography>


### PR DESCRIPTION
After replacing the old logo by the new one, one card inside the help center (the one with the new logo) doesn't have the same height as the others. This PR fixes it, as it isn't very esthetic. 