### PR TITLE
Fix api changes on tasks in preparation for v0.28.0

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,10 +9,10 @@ Cypress.Commands.add('deleteAllIndexes', async () => {
       host,
       apiKey,
     })
-    const indexes = await client.getIndexes()
+    const { results: indexes } = await client.getIndexes()
     indexes.forEach(async (index) => {
       const task = await client.deleteIndex(index.uid)
-      await client.waitForTask(task.uid)
+      await client.waitForTask(task.taskUid)
     })
   } catch (e) {
     console.log({ e })
@@ -26,7 +26,7 @@ Cypress.Commands.add('createIndex', async (uid) => {
       apiKey,
     })
     const task = await client.createIndex(uid)
-    await client.waitForTask(task.uid)
+    await client.waitForTask(task.taskUid)
   } catch (e) {
     console.log({ e })
   }
@@ -40,7 +40,7 @@ Cypress.Commands.add('addDocuments', async (uid, documents) => {
     })
     const index = await client.getIndex(uid)
     const task = await index.addDocuments(documents)
-    await client.waitForTask(task.uid)
+    await client.waitForTask(task.taskUid)
   } catch (e) {
     console.log({ e })
   }


### PR DESCRIPTION
the Tasks api has changed. An async route now returns a SummerizedTask which contains a `taskUid` instead of an `uid`. See [this issue](https://github.com/meilisearch/meilisearch/issues/2377)