### PR TITLE
Fix CI cypress fail after upgrade to node 16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,9 @@ jobs:
         run: yarn lint && yarn prettier-check
   cypress_no_meilisearch:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+    container:
+      image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+      options: --user 1001
     steps:
       - uses: actions/checkout@v3
       - name: Setup node and cache
@@ -54,7 +56,9 @@ jobs:
           path: cypress/videos
   cypress_meilisearch-no-api-key:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+    container:
+      image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+      options: --user 1001
     services:
       meilisearch:
         image: getmeili/meilisearch:v0.27.0rc1
@@ -93,7 +97,9 @@ jobs:
           path: cypress/videos
   cypress_meilisearch-api-key:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+    container:
+      image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+      options: --user 1001
     services:
       meilisearch:
         image: getmeili/meilisearch:v0.27.0rc1


### PR DESCRIPTION
CI was failing after the upgrade to node 16:

<img width="714" alt="Capture d’écran 2022-07-06 à 06 13 44" src="https://user-images.githubusercontent.com/30866152/177467031-cb1785f6-f2ae-4fc1-b380-27b5272d33aa.png">

This PR fixes it