### PR TITLE
Accessibility: make pressing the enter key, validate the admin key modal #280

### DIFF
--- a/cypress/e2e/test-api-key-required.cy.js
+++ b/cypress/e2e/test-api-key-required.cy.js
@@ -17,12 +17,23 @@ describe(`Test API key required`, () => {
     cy.contains('Enter your admin API key')
   })
 
-  it('Should fail on wrong API key', () => {
+  it('Should fail on wrong API key triggered with mouse click', () => {
     cy.get('div[aria-label=ask-for-api-key]').within(() => {
       cy.get('input[name="apiKey"]')
         .type(WRONG_APIKEY)
         .should('have.value', WRONG_APIKEY)
       cy.get('button').contains('Go').click()
+      cy.wait(WAITING_TIME)
+      cy.contains('The provided API key is invalid.')
+    })
+  })
+
+  it('Should fail on wrong API key triggered with enter key', () => {
+    cy.get('div[aria-label=ask-for-api-key]').within(() => {
+      cy.get('input[name="apiKey"]')
+        .type(WRONG_APIKEY)
+        .should('have.value', WRONG_APIKEY)
+      cy.get('input[name="apiKey"]').type('{enter}')
       cy.wait(WAITING_TIME)
       cy.contains('The provided API key is invalid.')
     })

--- a/src/components/ApiKeyModalContent.js
+++ b/src/components/ApiKeyModalContent.js
@@ -58,6 +58,11 @@ const ApiKeyModalContent = ({ closeModal }) => {
           type="text"
           value={value}
           onChange={(e) => setValue(e.target.value)}
+          onKeyPress={(e) => {
+            if (e.key === 'Enter') {
+              updateClient()
+            }
+          }}
         />
         <Button
           variant="filled"


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #280

## What does this PR do?
- This PR have solved the issue of key enter on API KEY modal

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

### Screenshot:
On key enter, field will be validate
![image](https://user-images.githubusercontent.com/30138146/193558239-fb0b27aa-aaf7-4a56-b077-20990f1da62d.png)


Thank you so much for contributing to Meilisearch!
