### PR TITLE
Fix compatibility with Meilisearch line in README for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ If you want to contribute to this project, please make sure to read [the contrib
 
 ## Compatibility with Meilisearch
 
-The current version of the mini-dashboard only guarantees the compatibility with the [version v0.30.x of Meilisearch](https://github.com/meilisearch/meilisearch/releases).
+The current version of the mini-dashboard only guarantees the compatibility with the [version v0.30.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0).


### PR DESCRIPTION
While this is the prefered way I would want to achieve (see [this issue](https://github.com/meilisearch/integration-automations/issues/122)), the pre-release script only works when the versions are provided with the patch version.

Until this process is changed in the scripts, it is better to keep the compatibility line consistent with the other SDK's