### PR TITLE
Fix crash when nesting field contains value key

### DIFF
--- a/src/components/Results/Hit.js
+++ b/src/components/Results/Hit.js
@@ -135,8 +135,21 @@ const JsonRepresentor = ({
   )
 }
 
-const FieldValue = ({ value, hit, objectKey }) => {
+function getFieldValueType(value) {
   if (isArray(value)) {
+    return 'array'
+  }
+  if (isObject(value)) {
+    return 'object'
+  }
+
+  return typeof value
+}
+
+const FieldValue = ({ hit, objectKey }) => {
+  const fieldValueType = getFieldValueType(hit[objectKey])
+
+  if (fieldValueType === 'array') {
     return (
       <JsonRepresentor
         value={hit[objectKey]}
@@ -147,7 +160,8 @@ const FieldValue = ({ value, hit, objectKey }) => {
       />
     )
   }
-  if (isObject(value) && !value.value) {
+
+  if (fieldValueType === 'object') {
     return (
       <JsonRepresentor
         value={hit[objectKey]}
@@ -159,8 +173,11 @@ const FieldValue = ({ value, hit, objectKey }) => {
     )
   }
 
-  // Handling Links
-  if (value?.value?.match(/^https?:\/\/[^\s]+$/)) {
+  // Wrap link in <a> tag
+  if (
+    fieldValueType === 'string' &&
+    hit[objectKey].match(/^https?:\/\/[^\s]+$/)
+  ) {
     return (
       <Link href={hit[objectKey]}>
         <Highlight hit={hit} attribute={objectKey} />
@@ -195,16 +212,16 @@ const Hit = ({ hit, imageKey }) => {
         )}
       </Box>
       <ContentContainer>
-        {documentProperties
+        {Object.keys(hit._highlightResult)
           .slice(0, displayMore ? hit.length : 6)
-          .map(([key, value]) => (
+          .map((key) => (
             <div key={key}>
               <Grid>
                 <HitKey variant="typo10" color="gray.6">
                   {key}
                 </HitKey>
                 <HitValue>
-                  <FieldValue value={value} hit={hit} objectKey={key} />
+                  <FieldValue hit={hit} objectKey={key} />
                 </HitValue>
               </Grid>
               <Hr />


### PR DESCRIPTION
fixes: #377 

The crash was due to the way `instantsearch` transforms fields when they are highlighted. For example, given this document:

```js
 {
    id: 1,
    foo: { some_property: "abc", value: { value: "plouf"}  },
    otherObject: { some_property: "abc", paf: 1  },
    url: "https://x.com/img.png",
    test: [1, 2, 3]
  }
```

When returned by instantsearch, they are transformed the following way:

```js
{
    id: 1,
    foo: { some_property: "abc", value: { value: "plouf"}  },
    otherObject: { some_property: "abc", paf: 1  },
    url: "https://raw.githubusercontent.com/meilisearch/integration-guides/main/assets/logos/meilisearch_js.svg",
    test: [1, 2, 3],
    _formatted: {
      id: { value: '1'}, // nested in value
      foo: { some_property: "abc", value: { value: "plouf"}  }, // not changed
      otherObject: { some_property: "abc", paf: 1  }, // not changed
      url: { value: "https://x.com/img.png" }, // nested in value
      test: [1, 2, 3] // not changed
    }
  }
```

The crash was due to us looking inside the fields value for a `value` field and assuming from that that it contains a string. 
Why do we assume it was a string? Meilisearch transforms primitives into string in the `_formatted` field, and none-primitives field are left unchanged, as you can see above: `id` was changed into a string but `foo` kept its type.

Unfortunately, since in `foo`, there is a `value` field, we mistakenly tried to string match on it. Since the [`match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) function of javascript only works on strings, it crashed.

The bug fix looks at the type when it is `not` highlighted and assumes that all fields that are either an object or an array are not going to be highlighted and thus we do not need to look into it for a `value` field.