### PR TITLE
Ignore dev dependencies in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
       - dependencies
     ignore:
       - dependency-name: '*storybook*'
+      - dependency-name: "*eslint*"
+      - dependency-name: "*prettier*"
+      - dependency-name: "*cypress*"


### PR DESCRIPTION
Styling, testing, and other none production-related dependencies are ignored in this PR. This avoids unnecessary maintenance on low-importance tasks.