### PR TITLE
Fix show more button not displaying all fields

### DIFF
--- a/src/components/Results/Hit.js
+++ b/src/components/Results/Hit.js
@@ -213,7 +213,7 @@ const Hit = ({ hit, imageKey }) => {
       </Box>
       <ContentContainer>
         {Object.keys(hit._highlightResult)
-          .slice(0, displayMore ? hit.length : 6)
+          .slice(0, displayMore ? Object.keys(hit).length : 6)
           .map((key) => (
             <div key={key}>
               <Grid>


### PR DESCRIPTION
Because show more was using the number of hits instead of the number of fields in a hit, the slice method was not using the right numbers.

