### PR TITLE
Update "Set your API key (optional)" link

### DIFF
--- a/src/components/OnBoarding.js
+++ b/src/components/OnBoarding.js
@@ -81,7 +81,7 @@ const OnBoarding = () => (
       <OnBoardingCard
         number="1"
         title="Set your API key (optional)"
-        href="https://www.meilisearch.com/docs/learn/security/master_api_keys"
+        href="https://meilisearch.com/docs/learn/security/master_api_keys"
         icon={<KeyBig />}
       />
       <OnBoardingCard

--- a/src/components/OnBoarding.js
+++ b/src/components/OnBoarding.js
@@ -81,7 +81,7 @@ const OnBoarding = () => (
       <OnBoardingCard
         number="1"
         title="Set your API key (optional)"
-        href="https://docs.meilisearch.com/reference/features/authentication.html#master-key"
+        href="https://www.meilisearch.com/docs/learn/security/master_api_keys"
         icon={<KeyBig />}
       />
       <OnBoardingCard


### PR DESCRIPTION
The current link (`https://www.meilisearch.com/docs/reference/features/authentication#master-key`) gives a 404. This PR updates it to the master and API keys guide.