### PR TITLE
Update README.md with new bors link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://github.com/prettier/prettier"><img src="https://img.shields.io/badge/styled_with-prettier-ff69b4.svg" alt="Prettier"></a>
   <a href="https://github.com/meilisearch/mini-dashboard/blob/main/LICENCE"><img src="https://img.shields.io/badge/license-MIT-informational" alt="License"></a>
-  <a href="https://app.bors.tech/repositories/32634"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
+  <a href="https://ms-bors.herokuapp.com/repositories/55"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
 </p>
 <br/>
 


### PR DESCRIPTION
Using our self hosted bors since the GitHub one is deprecated