### PR TITLE
Add a Fancy Cloud Button

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
   },
   "rules": {
     "semi": 0,
+    "no-param-reassign": 0,
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "prettier/prettier": [
       "error",

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -106,6 +106,27 @@ const variants = {
       background-color: ${(p) => p.theme.colors.gray[10]};
     }
   `,
+  cloud: css`
+    padding: 0 24px;
+    min-width: 128px;
+    background-color: ${(p) => p.theme.colors.cloud.default};
+    border: 1px solid ${(p) => p.theme.colors.cloud.default};
+    color: white;
+    svg {
+      color: white;
+    }
+
+    &:hover,
+    &:focus,
+    &:active {
+      background-color: ${(p) => p.theme.colors.cloud.hover};
+    }
+
+    &[aria-disabled='true'] {
+      background-color: ${(p) => Color(p.theme.colors.gray[2]).alpha(0.4)};
+      border-color: transparent;
+    }
+  `,
 }
 
 const sizes = {
@@ -196,6 +217,7 @@ Button.propTypes = {
     'clean',
     'link',
     'grayscale',
+    'cloud',
   ]),
   /**
    * Buttons's size

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -127,6 +127,20 @@ const Header = ({
             style={{ width: 216 }}
             onClick={refreshIndexes}
           />
+          <Button
+            variant="filled"
+            as="a"
+            target="_blank"
+            href="https://www.meilisearch.com/pricing"
+            style={{
+              textDecoration: 'none',
+              width: '100%',
+              padding: 0,
+              marginRight: 20,
+            }}
+          >
+            Try the Cloud
+          </Button>
           <ApiKey requireApiKeyToWork={requireApiKeyToWork} />
         </Box>
         <HelpCenter />

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -133,7 +133,7 @@ const Header = ({
               variant="cloud"
               as="a"
               target="_blank"
-              href="https://www.meilisearch.com/pricing"
+              href="https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=integration&utm_medium=minidashboard"
               style={{
                 textDecoration: 'none',
                 width: '100%',

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -5,6 +5,7 @@ import { DialogDisclosure, useDialogState } from 'reakit/Dialog'
 
 import ApiKeyModalContent from 'components/ApiKeyModalContent'
 import Button from 'components/Button'
+import Sparkles from 'components/Sparkles'
 import Link from 'components/Link'
 import Modal from 'components/Modal'
 import NoSelectOption from 'components/NoSelectOption'
@@ -127,20 +128,21 @@ const Header = ({
             style={{ width: 216 }}
             onClick={refreshIndexes}
           />
-          <Button
-            variant="cloud"
-            as="a"
-            target="_blank"
-            href="https://www.meilisearch.com/pricing"
-            style={{
-              textDecoration: 'none',
-              width: '100%',
-              padding: 0,
-              marginRight: 20,
-            }}
-          >
-            Try the Cloud
-          </Button>
+          <Sparkles style={{ marginRight: 20 }}>
+            <Button
+              variant="cloud"
+              as="a"
+              target="_blank"
+              href="https://www.meilisearch.com/pricing"
+              style={{
+                textDecoration: 'none',
+                width: '100%',
+                padding: 0,
+              }}
+            >
+              Try the Cloud
+            </Button>
+          </Sparkles>
           <ApiKey requireApiKeyToWork={requireApiKeyToWork} />
         </Box>
         <HelpCenter />

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -128,7 +128,7 @@ const Header = ({
             onClick={refreshIndexes}
           />
           <Button
-            variant="filled"
+            variant="cloud"
             as="a"
             target="_blank"
             href="https://www.meilisearch.com/pricing"

--- a/src/components/Sparkles.js
+++ b/src/components/Sparkles.js
@@ -1,0 +1,163 @@
+import React from 'react'
+import styled, { keyframes } from 'styled-components'
+
+const DEFAULT_COLOR = '#FFC700'
+
+/* Move this in its own module */
+
+const random = (min, max) => Math.floor(Math.random() * (max - min)) + min
+
+const range = (start, end, step = 1) => {
+  const output = []
+  if (typeof end === 'undefined') {
+    end = start
+    start = 0
+  }
+  for (let i = start; i < end; i += step) {
+    output.push(i)
+  }
+  return output
+}
+
+const useRandomInterval = (callback, minDelay, maxDelay) => {
+  const timeoutId = React.useRef(null)
+  const savedCallback = React.useRef(callback)
+  React.useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+  React.useEffect(() => {
+    const isEnabled =
+      typeof minDelay === 'number' && typeof maxDelay === 'number'
+
+    if (isEnabled) {
+      const handleTick = () => {
+        const nextTickAt = random(minDelay, maxDelay)
+        timeoutId.current = window.setTimeout(() => {
+          savedCallback.current()
+          handleTick()
+        }, nextTickAt)
+      }
+      handleTick()
+    }
+    return () => window.clearTimeout(timeoutId.current)
+  }, [minDelay, maxDelay])
+
+  const cancel = React.useCallback(
+    () => window.clearTimeout(timeoutId.current),
+    []
+  )
+
+  return cancel
+}
+
+/* --- */
+
+const generateSparkle = (color) => {
+  const sparkle = {
+    id: String(random(10000, 99999)),
+    createdAt: Date.now(),
+    color,
+    size: random(10, 20),
+    style: {
+      top: `${random(0, 100)}%`,
+      left: `${random(0, 100)}%`,
+    },
+  }
+  return sparkle
+}
+
+const Sparkles = ({ color = DEFAULT_COLOR, children, ...delegated }) => {
+  const [sparkles, setSparkles] = React.useState(() =>
+    range(3).map(() => generateSparkle(color))
+  )
+
+  useRandomInterval(
+    () => {
+      const sparkle = generateSparkle(color)
+      const now = Date.now()
+      const nextSparkles = sparkles.filter((sp) => {
+        const delta = now - sp.createdAt
+        return delta < 750
+      })
+      nextSparkles.push(sparkle)
+      setSparkles(nextSparkles)
+    },
+    50,
+    450
+  )
+
+  return (
+    <Wrapper {...delegated}>
+      {sparkles.map((sparkle) => (
+        <Sparkle
+          key={sparkle.id}
+          color={sparkle.color}
+          size={sparkle.size}
+          style={sparkle.style}
+        />
+      ))}
+      <ChildWrapper>{children}</ChildWrapper>
+    </Wrapper>
+  )
+}
+
+const Sparkle = ({ size, color, style }) => {
+  const path =
+    'M26.5 25.5C19.0043 33.3697 0 34 0 34C0 34 19.1013 35.3684 26.5 43.5C33.234 50.901 34 68 34 68C34 68 36.9884 50.7065 44.5 43.5C51.6431 36.647 68 34 68 34C68 34 51.6947 32.0939 44.5 25.5C36.5605 18.2235 34 0 34 0C34 0 33.6591 17.9837 26.5 25.5Z'
+  return (
+    <SparkleWrapper style={style}>
+      <SparkleSvg width={size} height={size} viewBox="0 0 68 68" fill="none">
+        <path d={path} fill={color} />
+      </SparkleSvg>
+    </SparkleWrapper>
+  )
+}
+
+const comeInOut = keyframes`
+  0% {
+    transform: scale(0);
+  }
+  50% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0);
+  }
+`
+
+const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(180deg);
+  }
+`
+
+const Wrapper = styled.span`
+  display: inline-block;
+  position: relative;
+`
+
+const SparkleWrapper = styled.span`
+  position: absolute;
+  display: block;
+  z-index: 1;
+  @media (prefers-reduced-motion: no-preference) {
+    animation: ${comeInOut} 700ms forwards;
+  }
+`
+
+const SparkleSvg = styled.svg`
+  display: block;
+  @media (prefers-reduced-motion: no-preference) {
+    animation: ${spin} 1000ms linear;
+  }
+`
+
+const ChildWrapper = styled.strong`
+  position: relative;
+  font-weight: bold;
+`
+
+export default Sparkles

--- a/src/theme.js
+++ b/src/theme.js
@@ -9,7 +9,7 @@ const theme = {
     },
     cloud: {
       default: '#2F016D',
-      hover: '#370E6E',
+      hover: '#442E9D',
     },
     gray: [
       '#39486E', // 0

--- a/src/theme.js
+++ b/src/theme.js
@@ -7,6 +7,10 @@ const theme = {
       light: '#FFDBE7',
       lighter: '#FDEEF3',
     },
+    cloud: {
+      default: '#2F016D',
+      hover: '#370E6E',
+    },
     gray: [
       '#39486E', // 0
       '#4F5C7E',


### PR DESCRIPTION
This pull request adds a new fancy button that directly links to the pricing page of Meilisearch. I added some sparkling to make it a little more fun and visible. I will ask for advice on the button text. Currently, it says _Try the Cloud_. I thought about _Easier on the Cloud_, but it's too long.

I followed [this tutorial from _JoshwComeau_ for the sparkles](https://www.joshwcomeau.com/react/animated-sparkles-in-react/) and did the rest myself.

https://github.com/meilisearch/mini-dashboard/assets/3610253/4918136a-545a-4027-bd3d-0a416c952407