### PR TITLE
Retrigger getIndexes on empty index search

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -128,6 +128,12 @@ const App = () => {
         } else {
           setCurrentIndex(options[0])
         }
+        setISClient(
+          instantMeilisearch(baseUrl, apiKey, {
+            primaryKey: 'id',
+            clientAgents,
+          })
+        )
       } else {
         setCurrentIndex(null)
       }

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -117,7 +117,10 @@ const Header = ({
           )}
         </Box>
         <Box display="flex">
-          <SearchBox />
+          <SearchBox
+            refreshIndexes={refreshIndexes}
+            currentIndex={currentIndex}
+          />
           <Select
             options={indexes}
             icon={<Indexes style={{ height: 22 }} />}

--- a/src/components/SearchBox.js
+++ b/src/components/SearchBox.js
@@ -10,24 +10,29 @@ const SearchIcon = styled(SearchMedium)`
   color: ${(p) => p.theme.colors.gray[2]};
 `
 
-const SearchBox = connectSearchBox(({ currentRefinement, refine }) => {
-  const [value, setValue] = React.useState(currentRefinement)
+const SearchBox = connectSearchBox(
+  ({ currentRefinement, refine, refreshIndexes, currentIndex }) => {
+    const [value, setValue] = React.useState(currentRefinement)
 
-  React.useEffect(() => {
-    refine(value)
-  }, [value])
+    React.useEffect(() => {
+      if (currentIndex?.stats?.numberOfDocuments === 0) {
+        refreshIndexes()
+      }
+      refine(value)
+    }, [value])
 
-  return (
-    <Input
-      type="search"
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      clear={() => setValue('')}
-      placeholder="Search something"
-      icon={<SearchIcon />}
-      style={{ width: 520 }}
-    />
-  )
-})
+    return (
+      <Input
+        type="search"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        clear={() => setValue('')}
+        placeholder="Search something"
+        icon={<SearchIcon />}
+        style={{ width: 520 }}
+      />
+    )
+  }
+)
 
 export default SearchBox


### PR DESCRIPTION
This PR adds a behavior where if you make a search request (you write something in the searchbar), the `getIndexes` method is re-triggered. Updating the stats of the index and showcasing its documents without having to reload the page.

fixes: #300