### PR TITLE
Add noindex metatag to prevent search engines from indexing the mini-dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+  <meta name="robots" content="noindex" />
   <meta charset="utf-8" />
   <link rel="icon" href="%PUBLIC_URL%/favicon-32x32.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #448 

## What does this PR do?
Adds a `noindex` metatag to prevent search engines from indexing the deployed mini-dashboards.
## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
