### PR TITLE
Always enable load more button

### DIFF
--- a/src/components/Results/InfiniteHits.js
+++ b/src/components/Results/InfiniteHits.js
@@ -46,7 +46,7 @@ const findImageKey = async (array) => {
   return imageField?.[0]
 }
 
-const InfiniteHits = connectInfiniteHits(({ hits, hasMore, refineNext }) => {
+const InfiniteHits = connectInfiniteHits(({ hits, refineNext }) => {
   const [imageKey, setImageKey] = React.useState(false)
 
   React.useEffect(async () => {
@@ -74,16 +74,16 @@ const InfiniteHits = connectInfiniteHits(({ hits, hasMore, refineNext }) => {
           />
         </Card>
       )} */}
-      {hasMore && (
-        <Button
-          size="small"
-          variant="bordered"
-          onClick={refineNext}
-          style={{ margin: '0 auto', marginTop: 32 }}
-        >
-          Load more
-        </Button>
-      )}
+
+      <Button
+        size="small"
+        variant="bordered"
+        onClick={refineNext}
+        style={{ margin: '0 auto', marginTop: 32 }}
+      >
+        Load more
+      </Button>
+
       <ScrollToTop />
     </div>
   )


### PR DESCRIPTION
Currently the load more button only appeared when the `hasMore` value in the `infiniteHits` connector is true. 
Unfortunately, because of a different way to handle the pagination with instant-meilisearch, it seems that variable is always `false`. 

Since it does not throw an error when you click on the load more button even if there are no more hits to load, I think we take no risk in having that button always on screen.

It's a quick win :) 