### PR TITLE
Fix bug where interface crashes if hit has no field

### DIFF
--- a/src/components/Results/Hit.js
+++ b/src/components/Results/Hit.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 import ReactJson from 'react-json-view'
 import { LazyLoadImage } from 'react-lazy-load-image-component'
@@ -197,7 +197,17 @@ const FieldValue = ({ hit, objectKey }) => {
 
 const Hit = ({ hit, imageKey }) => {
   const [displayMore, setDisplayMore] = React.useState(false)
-  const documentProperties = Object.entries(hit._highlightResult)
+  const hasFields = !!hit._highlightResult
+  const documentProperties = hasFields
+    ? Object.entries(hit._highlightResult)
+    : []
+
+  useEffect(() => {
+    if (!hit._highlightResult) {
+      console.warn('Your hits have no field. Please check your index settings.')
+    }
+  }, [])
+
   return (
     <CustomCard>
       <Box width={240} mr={4} flexShrink={0}>
@@ -212,21 +222,22 @@ const Hit = ({ hit, imageKey }) => {
         )}
       </Box>
       <ContentContainer>
-        {Object.keys(hit._highlightResult)
-          .slice(0, displayMore ? Object.keys(hit).length : 6)
-          .map((key) => (
-            <div key={key}>
-              <Grid>
-                <HitKey variant="typo10" color="gray.6">
-                  {key}
-                </HitKey>
-                <HitValue>
-                  <FieldValue hit={hit} objectKey={key} />
-                </HitValue>
-              </Grid>
-              <Hr />
-            </div>
-          ))}
+        {hasFields &&
+          Object.keys(hit._highlightResult)
+            .slice(0, displayMore ? Object.keys(hit).length : 6)
+            .map((key) => (
+              <div key={key}>
+                <Grid>
+                  <HitKey variant="typo10" color="gray.6">
+                    {key}
+                  </HitKey>
+                  <HitValue>
+                    <FieldValue hit={hit} objectKey={key} />
+                  </HitValue>
+                </Grid>
+                <Hr />
+              </div>
+            ))}
         {documentProperties.length > 6 && !displayMore && (
           <Grid>
             <HitKey variant="typo10" color="gray.6">

--- a/src/components/Results/index.js
+++ b/src/components/Results/index.js
@@ -27,8 +27,7 @@ import NoResultForRequest from './NoResultForRequest'
 const ConnectedStats = connectStats((props) => <Stats {...props} />)
 
 const Results = connectStateResults(({ searchResults }) => {
-  // const [mode, setMode] = useLocalStorage('mode', 'fancy')
-  const hasResults = searchResults?.nbHits !== 0
+  const hasResults = !!searchResults && searchResults?.nbHits !== 0
 
   return (
     <>


### PR DESCRIPTION
# Pull Request

## What does this PR do?
It can happen that a document contains no fields if none of these fields are present in the displayedAttributes setting. For example, if I have a document with an id field, but in my displayedAttributes setting I did not include `id`, the hits I receive from a search are empty
```
{
hits : [ {} ]
}

```

In this particular case, the mini-dashboard would crash.

In this PR I added a safeguard where if there are no field, a document still appears but empty

<img width="1341" alt="Screenshot 2023-07-12 at 13 50 54" src="https://github.com/meilisearch/mini-dashboard/assets/33010418/ad970e4a-fa84-424b-930f-29cd8b87defd">

I also added a warning in their console just in case they want to understand what is happening

<img width="523" alt="Screenshot 2023-07-12 at 13 54 30" src="https://github.com/meilisearch/mini-dashboard/assets/33010418/ba5348cd-0684-415d-bc18-79725c9e283f">

