### PR TITLE
Disable eslint error on a console warning

### DIFF
--- a/src/components/Results/Hit.js
+++ b/src/components/Results/Hit.js
@@ -204,6 +204,7 @@ const Hit = ({ hit, imageKey }) => {
 
   useEffect(() => {
     if (!hit._highlightResult) {
+      // eslint-disable-next-line no-console
       console.warn('Your hits have no field. Please check your index settings.')
     }
   }, [])


### PR DESCRIPTION
Disable eslint on a line using a warning to inform user that their document are empty.