### PR TITLE
Update link to the cloud page

### DIFF
--- a/src/components/CloudBanner.js
+++ b/src/components/CloudBanner.js
@@ -62,7 +62,7 @@ const CloudBanner = () => {
             <Typography variant="typo15" color="white">
               Say goodbye to server management, and manual updates with{' '}
               <Link
-                href="https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=integration&utm_medium=minidashboard"
+                href="https://www.meilisearch.com/cloud?utm_campaign=oss&utm_source=integration&utm_medium=minidashboard"
                 color="white"
               >
                 <Typography variant="typo14" color="white">


### PR DESCRIPTION
Updates the link in the cloud banner now pointing to the new cloud landing page instead of the pricing page.