### PR TITLE
Update dependabot.yml from ignore list to allow list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,11 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
     labels:
       - skip-changelog
       - dependencies
-    ignore:
-      - dependency-name: '*storybook*'
-      - dependency-name: "*eslint*"
-      - dependency-name: "*prettier*"
-      - dependency-name: "*cypress*"
+    allow:
+      - dependency-name: '@meilisearch/instant-meilisearch'
+      - dependency-name: 'meilisearch'
+      


### PR DESCRIPTION
To avoid being spammed with package updates, we changed from a ignore list to an allow list in a monthly interval.