### PR TITLE
fix: search request amount made on page arrival

### DIFF
--- a/cypress/e2e/test-api-key-query-param.cy.js
+++ b/cypress/e2e/test-api-key-query-param.cy.js
@@ -20,6 +20,7 @@ describe(`Test API key required with query params`, () => {
   })
 
   it('Should display the movies', () => {
+    cy.wait(WAITING_TIME)
     cy.get('ul')
       .children()
       .should(($p) => {

--- a/cypress/e2e/test-interface.cy.js
+++ b/cypress/e2e/test-interface.cy.js
@@ -59,6 +59,7 @@ describe(`Test interface`, () => {
 
   it('Shouldn’t contain a "Show more" button if a document has less than 6 fields', () => {
     cy.get('button[aria-haspopup=menu]').click()
+    cy.wait(WAITING_TIME)
     cy.get('button[role=menuitem]').contains('pokemon').click()
     cy.get('ul')
       .children()
@@ -70,6 +71,7 @@ describe(`Test interface`, () => {
 
   it('Should display more fields if the user clicks on the "Show more" button', () => {
     cy.get('button[aria-haspopup=menu]').click()
+    cy.wait(WAITING_TIME)
     cy.get('button[role=menuitem]').contains('movies').click()
     cy.get('ul')
       .children()

--- a/cypress/e2e/test-select-indexes.cy.js
+++ b/cypress/e2e/test-select-indexes.cy.js
@@ -1,5 +1,7 @@
 const WAITING_TIME = Cypress.env('waitingTime')
 
+// TODO: refacto tests to get rid of the WAITING_TIME
+
 describe(`Test indexes`, () => {
   before(() => {
     cy.deleteAllIndexes()
@@ -39,6 +41,7 @@ describe(`Test indexes`, () => {
 
   it('Should list all the indexes inside the select', () => {
     cy.get('button[aria-haspopup=menu]').click()
+    cy.wait(WAITING_TIME)
     cy.get('div[role=menu]')
       .children()
       .should(($p) => {
@@ -55,6 +58,7 @@ describe(`Test indexes`, () => {
 
   it('Should display an indexes documents', () => {
     cy.get('button[aria-haspopup=menu]').click()
+    cy.wait(WAITING_TIME)
     cy.get('button[role=menuitem]').contains('movies').click()
     cy.get('ul')
       .children()
@@ -65,6 +69,7 @@ describe(`Test indexes`, () => {
 
   it('Should display the documents of an other index on click on it', () => {
     cy.get('button[aria-haspopup=menu]').click()
+    cy.wait(WAITING_TIME)
     cy.get('button[role=menuitem]').contains('pokemon').click()
     cy.get('ul').children().should('have.length', 3)
     cy.get('ul')

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 /* eslint-disable react/jsx-no-constructed-context-values */
 /* eslint-disable no-console */
 import React, { useState, useEffect, useCallback } from 'react'

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,8 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable react/jsx-no-constructed-context-values */
 /* eslint-disable no-console */
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import styled from 'styled-components'
-import { InstantSearch } from 'react-instantsearch-dom'
 import { instantMeiliSearch as instantMeilisearch } from '@meilisearch/instant-meilisearch'
 import { useDialogState } from 'reakit/Dialog'
 import { MeiliSearch as Meilisearch } from 'meilisearch'
@@ -11,16 +11,15 @@ import ApiKeyContext from 'context/ApiKeyContext'
 import { useMeilisearchClientContext } from 'context/MeilisearchClientContext'
 import useLocalStorage from 'hooks/useLocalStorage'
 import ApiKeyModalContent from 'components/ApiKeyModalContent'
-import Box from 'components/Box'
-import EmptyView from 'components/EmptyView'
-import Header from 'components/Header/index'
+import Body from 'components/Body'
 import CloudBanner from 'components/CloudBanner'
 import Modal from 'components/Modal'
-import OnBoarding from 'components/OnBoarding'
 import NoMeilisearchRunning from 'components/NoMeilisearchRunning'
-import Results from 'components/Results'
-import Typography from 'components/Typography'
 import ApiKeyAwarenessBanner from 'components/ApiKeyAwarenessBanner'
+import getIndexesListWithStats from 'utils/getIndexesListWithStats'
+import shouldDisplayCloudBanner from 'utils/shouldDisplayCloudBanner'
+import shouldDisplayApiKeyModal from 'utils/shouldDisplayApiKeyModal'
+import hasAnApiKeySet from 'utils/hasAnApiKeySet'
 import clientAgents from './version/client-agents'
 
 export const baseUrl =
@@ -34,34 +33,10 @@ const Wrapper = styled.div`
   min-height: 100vh;
 `
 
-const Body = styled.div`
-  display: flex;
-  flex: 1;
-  width: 100%;
-  min-height: calc(100vh - 120px);
-`
-
-const Content = ({ currentIndex }) => {
-  if (!currentIndex) return <OnBoarding />
-  if (currentIndex?.stats?.numberOfDocuments > 0) return <Results />
-  return (
-    <EmptyView buttonLink="https://docs.meilisearch.com/reference/api/documents.html">
-      <Typography
-        variant="typo8"
-        style={{ textAlign: 'center' }}
-        mb={32}
-        color="gray.0"
-      >
-        There’s no document in the selected index
-      </Typography>
-    </EmptyView>
-  )
-}
-
 const App = () => {
   const [apiKey, setApiKey] = useLocalStorage('apiKey')
   const [indexes, setIndexes] = useState()
-  const [isMeilisearchRunning, setIsMeilisearchRunning] = useState(true)
+  const [isMeilisearchRunning, setIsMeilisearchRunning] = useState(false)
   const [requireApiKeyToWork, setRequireApiKeyToWork] = useState(false)
   const [currentIndex, setCurrentIndex] = useLocalStorage('currentIndex')
   const [showCloudBanner, setShowCloudBanner] = useState(true)
@@ -71,39 +46,18 @@ const App = () => {
   const {
     meilisearchJsClient,
     setMeilisearchJsClient,
-    instantMeilisearchClient,
     setInstantMeilisearchClient,
   } = useMeilisearchClientContext()
 
-  const handleBannerClose = () => {
-    setIsApiKeyBannerVisible(false)
-  }
-
-  const getIndexesList = async () => {
+  const getIndexesList = useCallback(async () => {
     try {
-      const res = await meilisearchJsClient.getStats()
-      const array = Object.entries(res.indexes)
-      const options = array
-        .reduce((prev, curr) => {
-          const currentOption = { uid: curr[0], stats: curr[1] }
-          return [...prev, currentOption]
-        }, [])
-        .sort((a, b) => a.uid.localeCompare(b.uid))
-
-      setIndexes(options)
-      if (options.length) {
-        if (currentIndex) {
-          setCurrentIndex(
-            options.find((option) => option.uid === currentIndex.uid)
-          )
-        } else {
-          setCurrentIndex(options[0])
-        }
-        setInstantMeilisearchClient(
-          instantMeilisearch(baseUrl, apiKey, {
-            primaryKey: 'id',
-            clientAgents,
-          }).searchClient
+      const indexesList = await getIndexesListWithStats(meilisearchJsClient)
+      setIndexes(indexesList)
+      if (indexesList && indexesList?.length > 0) {
+        setCurrentIndex(
+          currentIndex
+            ? indexesList.find((option) => option.uid === currentIndex.uid)
+            : indexesList[0]
         )
       } else {
         setCurrentIndex(null)
@@ -112,115 +66,68 @@ const App = () => {
       setCurrentIndex(null)
       console.log(error)
     }
-  }
+  }, [meilisearchJsClient, currentIndex])
 
-  useEffect(() => {
-    // Check if the API key is present on the url then put it in the local storage
+  // Check if the API key is present on the url then put it in the local storage
+  const getApiKeyFromUrl = useCallback(() => {
     const urlParams = new URLSearchParams(window.location.search)
     const apiKeyParam = urlParams.get('api_key')
-    const cloudBannerQueryParam = urlParams.get('cloud_banner')
-
-    if (cloudBannerQueryParam === 'false') {
-      setShowCloudBanner(false)
-    }
     if (apiKeyParam) {
       setApiKey(apiKeyParam)
       setIsApiKeyBannerVisible(true)
     }
-
-    // Check if an API key is required / a masterKey was set
-    const fetchWithoutApiKey = async () => {
-      try {
-        const tempClient = new Meilisearch({ host: baseUrl, clientAgents })
-        await tempClient.getIndexes()
-      } catch (err) {
-        console.log(err)
-        if (err.code === 'missing_authorization_header') {
-          setRequireApiKeyToWork(true)
-        } else {
-          setIsMeilisearchRunning(await meilisearchJsClient.isHealthy())
-        }
-      }
-    }
-
-    fetchWithoutApiKey()
-    getIndexesList()
   }, [])
 
   useEffect(() => {
-    if (apiKey) {
-      setInstantMeilisearchClient(
-        instantMeilisearch(baseUrl, apiKey, {
-          primaryKey: 'id',
-          clientAgents,
-        }).searchClient
-      )
+    setShowCloudBanner(shouldDisplayCloudBanner())
+    getApiKeyFromUrl()
+  }, [])
 
-      setMeilisearchJsClient(
-        new Meilisearch({
-          host: baseUrl,
-          apiKey,
-          clientAgents,
-        })
-      )
-    }
+  useEffect(() => {
+    setInstantMeilisearchClient(
+      instantMeilisearch(baseUrl, apiKey, {
+        primaryKey: 'id',
+        clientAgents,
+      }).searchClient
+    )
+
+    setMeilisearchJsClient(
+      new Meilisearch({
+        host: baseUrl,
+        apiKey,
+        clientAgents,
+      })
+    )
   }, [apiKey])
 
-  // Check if a modal asking for API Key should be displayed
-  useEffect(() => {
-    const shouldDisplayModal = async () => {
-      try {
-        await meilisearchJsClient.getIndexes()
-      } catch (err) {
-        console.log(err)
-        dialog.show()
-      }
-    }
-    if (requireApiKeyToWork) shouldDisplayModal()
-  }, [requireApiKeyToWork])
-
-  // Get the list of indexes
-  useEffect(() => {
+  useEffect(async () => {
+    setIsMeilisearchRunning(await meilisearchJsClient.isHealthy())
+    setRequireApiKeyToWork(await hasAnApiKeySet())
+    dialog.setVisible(await shouldDisplayApiKeyModal(meilisearchJsClient))
     getIndexesList()
-  }, [meilisearchJsClient, currentIndex?.uid])
+  }, [meilisearchJsClient])
 
   return (
     <ApiKeyContext.Provider value={{ apiKey, setApiKey }}>
       <Wrapper>
-        <InstantSearch
-          indexName={currentIndex ? currentIndex.uid : ''}
-          searchClient={instantMeilisearchClient}
-        >
-          {isApiKeyBannerVisible && (
-            <ApiKeyAwarenessBanner onClose={handleBannerClose} />
-          )}
-          {showCloudBanner && <CloudBanner />}
-          <Header
-            indexes={indexes}
+        {isApiKeyBannerVisible && (
+          <ApiKeyAwarenessBanner
+            onClose={() => setIsApiKeyBannerVisible(false)}
+          />
+        )}
+        {showCloudBanner && <CloudBanner />}
+        {isMeilisearchRunning ? (
+          <Body
             currentIndex={currentIndex}
+            indexes={indexes}
             setCurrentIndex={setCurrentIndex}
             requireApiKeyToWork={requireApiKeyToWork}
-            client={meilisearchJsClient}
-            refreshIndexes={getIndexesList}
-            isBannerVisible={isApiKeyBannerVisible}
+            getIndexesList={getIndexesList}
+            isApiKeyBannerVisible={isApiKeyBannerVisible}
           />
-          <Body>
-            {/* <Sidebar /> */}
-            <Box
-              width={928}
-              m="0 auto"
-              py={4}
-              display="flex"
-              flexDirection="column"
-            >
-              {isMeilisearchRunning ? (
-                <Content currentIndex={currentIndex} />
-              ) : (
-                <NoMeilisearchRunning />
-              )}
-            </Box>
-          </Body>
-        </InstantSearch>
+        ) : (
+          <NoMeilisearchRunning />
+        )}
         <Modal
           title={`Enter your admin API key${
             requireApiKeyToWork ? '' : ' (optional)'

--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ const App = () => {
   const [isMeilisearchRunning, setIsMeilisearchRunning] = useState(false)
   const [requireApiKeyToWork, setRequireApiKeyToWork] = useState(false)
   const [currentIndex, setCurrentIndex] = useLocalStorage('currentIndex')
-  const [showCloudBanner, setShowCloudBanner] = useState(true)
+  const [showCloudBanner, setShowCloudBanner] = useState(false)
   const [isApiKeyBannerVisible, setIsApiKeyBannerVisible] = useState(false)
   const dialog = useDialogState({ animated: true, visible: false })
 
@@ -79,7 +79,10 @@ const App = () => {
   }, [])
 
   useEffect(() => {
-    setShowCloudBanner(shouldDisplayCloudBanner())
+    const shouldCloudBannerBeDisplayed = shouldDisplayCloudBanner()
+    if (shouldCloudBannerBeDisplayed) {
+      setShowCloudBanner(shouldCloudBannerBeDisplayed)
+    }
     getApiKeyFromUrl()
   }, [])
 
@@ -101,10 +104,13 @@ const App = () => {
   }, [apiKey])
 
   useEffect(async () => {
-    setIsMeilisearchRunning(await meilisearchJsClient.isHealthy())
-    setRequireApiKeyToWork(await hasAnApiKeySet())
-    dialog.setVisible(await shouldDisplayApiKeyModal(meilisearchJsClient))
-    getIndexesList()
+    const isInstanceRunning = await meilisearchJsClient.isHealthy()
+    setIsMeilisearchRunning(isInstanceRunning)
+    if (isInstanceRunning) {
+      setRequireApiKeyToWork(await hasAnApiKeySet())
+      dialog.setVisible(await shouldDisplayApiKeyModal(meilisearchJsClient))
+      getIndexesList()
+    }
   }, [meilisearchJsClient])
 
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-constructed-context-values */
 /* eslint-disable no-console */
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { InstantSearch } from 'react-instantsearch-dom'
 import { instantMeiliSearch as instantMeilisearch } from '@meilisearch/instant-meilisearch'
@@ -114,7 +114,7 @@ const App = () => {
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Check if the API key is present on the url then put it in the local storage
     const urlParams = new URLSearchParams(window.location.search)
     const apiKeyParam = urlParams.get('api_key')
@@ -147,7 +147,7 @@ const App = () => {
     getIndexesList()
   }, [])
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (apiKey) {
       setInstantMeilisearchClient(
         instantMeilisearch(baseUrl, apiKey, {
@@ -167,7 +167,7 @@ const App = () => {
   }, [apiKey])
 
   // Check if a modal asking for API Key should be displayed
-  React.useEffect(() => {
+  useEffect(() => {
     const shouldDisplayModal = async () => {
       try {
         await meilisearchJsClient.getIndexes()
@@ -180,7 +180,7 @@ const App = () => {
   }, [requireApiKeyToWork])
 
   // Get the list of indexes
-  React.useEffect(() => {
+  useEffect(() => {
     getIndexesList()
   }, [meilisearchJsClient, currentIndex?.uid])
 

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import { InstantSearch } from 'react-instantsearch-dom'
+
+import { useMeilisearchClientContext } from 'context/MeilisearchClientContext'
+import Box from 'components/Box'
+import Header from 'components/Header/index'
+import BodyWrapper from 'components/BodyWrapper'
+import EmptyView from 'components/EmptyView'
+import OnBoarding from 'components/OnBoarding'
+import Results from 'components/Results'
+import Typography from 'components/Typography'
+
+const IndexContent = ({ currentIndex }) => {
+  if (!currentIndex) return <OnBoarding />
+  if (currentIndex?.stats?.numberOfDocuments > 0) return <Results />
+  return (
+    <EmptyView buttonLink="https://docs.meilisearch.com/reference/api/documents.html">
+      <Typography
+        variant="typo8"
+        style={{ textAlign: 'center' }}
+        mb={32}
+        color="gray.0"
+      >
+        There’s no document in the selected index
+      </Typography>
+    </EmptyView>
+  )
+}
+
+const Body = ({
+  currentIndex,
+  indexes,
+  getIndexesList,
+  setCurrentIndex,
+  requireApiKeyToWork,
+  isApiKeyBannerVisible,
+}) => {
+  const { meilisearchJsClient, instantMeilisearchClient } =
+    useMeilisearchClientContext()
+
+  return (
+    <InstantSearch
+      indexName={currentIndex ? currentIndex.uid : ''}
+      searchClient={instantMeilisearchClient}
+    >
+      <Header
+        indexes={indexes}
+        currentIndex={currentIndex}
+        setCurrentIndex={setCurrentIndex}
+        requireApiKeyToWork={requireApiKeyToWork}
+        client={meilisearchJsClient}
+        refreshIndexes={getIndexesList}
+        isBannerVisible={isApiKeyBannerVisible}
+      />
+      <BodyWrapper>
+        {/* <Sidebar /> */}
+        <Box
+          width={928}
+          m="0 auto"
+          py={4}
+          display="flex"
+          flexDirection="column"
+        >
+          <IndexContent currentIndex={currentIndex} />
+        </Box>
+      </BodyWrapper>
+    </InstantSearch>
+  )
+}
+
+export default Body

--- a/src/components/BodyWrapper.js
+++ b/src/components/BodyWrapper.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+
+const BodyWrapper = styled.div`
+  display: flex;
+  flex: 1;
+  width: 100%;
+  min-height: calc(100vh - 120px);
+`
+
+export default BodyWrapper

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import Color from 'color'
 import { DialogDisclosure, useDialogState } from 'reakit/Dialog'
 
+import { useMeilisearchClientContext } from 'context/MeilisearchClientContext'
 import ApiKeyModalContent from 'components/ApiKeyModalContent'
 import Button from 'components/Button'
 import Link from 'components/Link'
@@ -70,19 +71,20 @@ const Header = ({
   setCurrentIndex,
   refreshIndexes,
   requireApiKeyToWork,
-  client,
   isBannerVisible,
 }) => {
+  const { meilisearchJsClient } = useMeilisearchClientContext()
   const [version, setVersion] = React.useState()
+
   React.useEffect(async () => {
     try {
-      const res = await client.getVersion()
+      const res = await meilisearchJsClient.getVersion()
       setVersion(res.pkgVersion)
     } catch (err) {
       // eslint-disable-next-line no-console
       console.log(err)
     }
-  }, [client])
+  }, [meilisearchJsClient])
 
   return (
     <HeaderWrapper top={isBannerVisible ? 55 : 0}>

--- a/src/components/NoMeilisearchRunning.js
+++ b/src/components/NoMeilisearchRunning.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import Typography from 'components/Typography'
+import EmptyView from 'components/EmptyView'
+
+const NoMeilisearchRunning = () => (
+  <EmptyView buttonLink="https://docs.meilisearch.com/learn/getting_started/quick_start.html">
+    <Typography
+      variant="typo8"
+      style={{ textAlign: 'center' }}
+      mb={3}
+      color="gray.0"
+    >
+      It seems like Meilisearch isn’t running, did you forget to start it?
+    </Typography>
+    <Typography
+      variant="typo8"
+      style={{ textAlign: 'center' }}
+      mb={32}
+      color="gray.2"
+    >
+      (Don’t forget to set an API Key if you want one)
+    </Typography>
+    <Typography
+      variant="typo8"
+      style={{ textAlign: 'center', fontSize: 40 }}
+      mb={56}
+    >
+      <span role="img" aria-label="face-with-monocle">
+        🧐
+      </span>
+    </Typography>
+  </EmptyView>
+)
+
+export default NoMeilisearchRunning

--- a/src/components/NoMeilisearchRunning.js
+++ b/src/components/NoMeilisearchRunning.js
@@ -1,35 +1,41 @@
 import React from 'react'
 import Typography from 'components/Typography'
 import EmptyView from 'components/EmptyView'
+import BodyWrapper from 'components/BodyWrapper'
+import Box from 'components/Box'
 
 const NoMeilisearchRunning = () => (
-  <EmptyView buttonLink="https://docs.meilisearch.com/learn/getting_started/quick_start.html">
-    <Typography
-      variant="typo8"
-      style={{ textAlign: 'center' }}
-      mb={3}
-      color="gray.0"
-    >
-      It seems like Meilisearch isn’t running, did you forget to start it?
-    </Typography>
-    <Typography
-      variant="typo8"
-      style={{ textAlign: 'center' }}
-      mb={32}
-      color="gray.2"
-    >
-      (Don’t forget to set an API Key if you want one)
-    </Typography>
-    <Typography
-      variant="typo8"
-      style={{ textAlign: 'center', fontSize: 40 }}
-      mb={56}
-    >
-      <span role="img" aria-label="face-with-monocle">
-        🧐
-      </span>
-    </Typography>
-  </EmptyView>
+  <BodyWrapper>
+    <Box width={928} m="0 auto" py={4} display="flex" flexDirection="column">
+      <EmptyView buttonLink="https://docs.meilisearch.com/learn/getting_started/quick_start.html">
+        <Typography
+          variant="typo8"
+          style={{ textAlign: 'center' }}
+          mb={3}
+          color="gray.0"
+        >
+          It seems like Meilisearch isn’t running, did you forget to start it?
+        </Typography>
+        <Typography
+          variant="typo8"
+          style={{ textAlign: 'center' }}
+          mb={32}
+          color="gray.2"
+        >
+          (Don’t forget to set an API Key if you want one)
+        </Typography>
+        <Typography
+          variant="typo8"
+          style={{ textAlign: 'center', fontSize: 40 }}
+          mb={56}
+        >
+          <span role="img" aria-label="face-with-monocle">
+            🧐
+          </span>
+        </Typography>
+      </EmptyView>
+    </Box>
+  </BodyWrapper>
 )
 
 export default NoMeilisearchRunning

--- a/src/context/MeilisearchClientContext.js
+++ b/src/context/MeilisearchClientContext.js
@@ -1,0 +1,62 @@
+import React, { useState, useMemo, createContext, useContext } from 'react'
+import { instantMeiliSearch as instantMeilisearch } from '@meilisearch/instant-meilisearch'
+import { MeiliSearch as Meilisearch } from 'meilisearch'
+import useLocalStorage from 'hooks/useLocalStorage'
+import { baseUrl } from 'App'
+import clientAgents from 'version/client-agents'
+
+const MeilisearchClientContext = createContext({
+  meilisearchJsClient: '',
+  setMeilisearchJsClient: () => {},
+  instantMeilisearchClient: '',
+  setInstantMeilisearchClient: () => {},
+})
+
+export const MeiliSearchClientProvider = ({ children }) => {
+  const [apiKey] = useLocalStorage('apiKey')
+
+  const [meilisearchJsClient, setMeilisearchJsClient] = useState(
+    new Meilisearch({
+      host: baseUrl,
+      apiKey,
+      clientAgents,
+    })
+  )
+  const [instantMeilisearchClient, setInstantMeilisearchClient] = useState(
+    instantMeilisearch(baseUrl, apiKey, {
+      primaryKey: 'id',
+      clientAgents,
+    }).searchClient
+  )
+
+  const contextValue = useMemo(
+    () => ({
+      meilisearchJsClient,
+      setMeilisearchJsClient,
+      instantMeilisearchClient,
+      setInstantMeilisearchClient,
+    }),
+    [
+      meilisearchJsClient,
+      setMeilisearchJsClient,
+      instantMeilisearchClient,
+      setInstantMeilisearchClient,
+    ]
+  )
+
+  return (
+    <MeilisearchClientContext.Provider value={contextValue}>
+      {children}
+    </MeilisearchClientContext.Provider>
+  )
+}
+
+export const useMeilisearchClientContext = () => {
+  const context = useContext(MeilisearchClientContext)
+  if (context === undefined) {
+    throw new Error(
+      'useMeilisearchClientContext must be used within a MeilisearchClientProvider'
+    )
+  }
+  return context
+}

--- a/src/context/MeilisearchClientContext.js
+++ b/src/context/MeilisearchClientContext.js
@@ -5,7 +5,7 @@ import useLocalStorage from 'hooks/useLocalStorage'
 import { baseUrl } from 'App'
 import clientAgents from 'version/client-agents'
 
-const MeilisearchClientContext = createContext({
+export const MeilisearchClientContext = createContext({
   meilisearchJsClient: '',
   setMeilisearchJsClient: () => {},
   instantMeilisearchClient: '',

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,14 @@ import { ThemeProvider } from 'styled-components'
 import theme from 'theme'
 import App from 'App'
 import GlobalStyle from 'GlobalStyle'
+import { MeiliSearchClientProvider } from 'context/MeilisearchClientContext'
 
 ReactDOM.render(
-  <ThemeProvider theme={theme}>
-    <GlobalStyle />
-    <App />
-  </ThemeProvider>,
+  <MeiliSearchClientProvider>
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      <App />
+    </ThemeProvider>
+  </MeiliSearchClientProvider>,
   document.getElementById('root')
 )

--- a/src/utils/getIndexesListWithStats.js
+++ b/src/utils/getIndexesListWithStats.js
@@ -1,0 +1,13 @@
+const getIndexesListWithStats = async (meilisearchJsClient) => {
+  const res = await meilisearchJsClient.getStats()
+  const array = Object.entries(res.indexes)
+  const indexesList = array
+    .reduce((prev, curr) => {
+      const currentOption = { uid: curr[0], stats: curr[1] }
+      return [...prev, currentOption]
+    }, [])
+    .sort((a, b) => a.uid.localeCompare(b.uid))
+  return indexesList
+}
+
+export default getIndexesListWithStats

--- a/src/utils/hasAnApiKeySet.js
+++ b/src/utils/hasAnApiKeySet.js
@@ -1,0 +1,18 @@
+import { MeiliSearch as Meilisearch } from 'meilisearch'
+import { baseUrl } from 'App'
+import clientAgents from 'version/client-agents'
+
+const hasAnApiKeySet = async () => {
+  try {
+    const tempClient = new Meilisearch({ host: baseUrl, clientAgents })
+    await tempClient.getIndexes()
+    return false
+  } catch (err) {
+    if (err.code === 'missing_authorization_header') {
+      return true
+    }
+    return false
+  }
+}
+
+export default hasAnApiKeySet

--- a/src/utils/shouldDisplayApiKeyModal.js
+++ b/src/utils/shouldDisplayApiKeyModal.js
@@ -1,0 +1,10 @@
+const shouldDisplayApiKeyModal = async (meilisearchJsClient) => {
+  try {
+    await meilisearchJsClient.getIndexes()
+    return false
+  } catch (err) {
+    return true
+  }
+}
+
+export default shouldDisplayApiKeyModal

--- a/src/utils/shouldDisplayCloudBanner.js
+++ b/src/utils/shouldDisplayCloudBanner.js
@@ -1,0 +1,7 @@
+const shouldDisplayCloudBanner = () => {
+  const urlParams = new URLSearchParams(window.location.search)
+  const cloudBannerQueryParam = urlParams.get('cloud_banner')
+  return cloudBannerQueryParam === 'true'
+}
+
+export default shouldDisplayCloudBanner


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Creation of a `MeilisearchClientContext` for maintainability (instead of passing down 2 clients to the components)
- Functions have been put in specific files (instead of inside the `useEffect`)
- Functions needing to stay in the `App` file are now wrapped inside a `useCallback`
- Some components have been put in specific files (instead of inside the `App` file)
- Fix the amount of search requests made on page load (from 20 down to 4)
- The Header now doesn't show up when Meilisearch isn't running (this caused re-rendering and search requests)
- Fix tests (addition of waiting_time as a quick fix, as Cypress is now too fast and CI was failing). Tests would need a refacto anyway 🤷 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
