### PR TITLE
fix(security): minimatch ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "eslint-plugin-react": "^7.31.11",
     "prettier": "^3.2.5",
     "storybook": "^8.0.10"
+  },
+  "resolutions": {
+    "**/recursive-readdir/**/minimatch": "^3.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11170,14 +11170,7 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==


### PR DESCRIPTION
# Pull Request

## What does this PR do?
The `minimatch` package has a vulnerability issue with versions < 3.0.5.
This package is used internally through `recursive-readdir`: 

<img width="837" alt="Capture d’écran 2024-05-14 à 10 34 44" src="https://github.com/meilisearch/mini-dashboard/assets/30866152/3c48152f-f247-40df-bc6a-4a14da92e734">

The problem is that `recursive-readdir` is used by react-script (create-react-app), which is not maintained anymore.

To fix this issue, the `package.json` has been updated with the [resolutions field](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) to update `minimatch` to the v3.0.5 (fixing the vulnerability) for the package using the vulnerable version (`recursive-readdir`)  

This should help fixing the vulnerability issue.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
