### PR TITLE
feat(rightPanel): store the state of the panel in the localStorage

### DIFF
--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { InstantSearch } from 'react-instantsearch-dom'
 import styled from 'styled-components'
-
 import { useMeilisearchClientContext } from 'context/MeilisearchClientContext'
+import useLocalStorage from 'hooks/useLocalStorage'
 import Box from 'components/Box'
 import Header from 'components/Header/index'
 import RightPanel from 'components/RightPanel'
@@ -45,11 +45,17 @@ const Body = ({
 }) => {
   const { meilisearchJsClient, instantMeilisearchClient } =
     useMeilisearchClientContext()
+  const [storedIsPanelOpen, setStoredIsPanelOpen] = useLocalStorage(
+    'meilisearch-panel-open',
+    true
+  )
 
   // Right-side panel
-  const [isRightPanelOpen, setIsRightPanelOpen] = React.useState(true)
+  const [isRightPanelOpen, setIsRightPanelOpen] =
+    React.useState(storedIsPanelOpen)
   const handleTogglePanel = React.useCallback(() => {
     setIsRightPanelOpen((isOpen) => !isOpen)
+    setStoredIsPanelOpen((isOpen) => !isOpen)
   }, [])
 
   return (
@@ -84,7 +90,10 @@ const Body = ({
       </ContentWrapper>
       <RightPanel
         isOpen={isRightPanelOpen}
-        onClose={() => setIsRightPanelOpen(false)}
+        onClose={() => {
+          setIsRightPanelOpen(false)
+          setStoredIsPanelOpen(false)
+        }}
       />
     </InstantSearch>
   )


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #589


## What does this PR do?
Save the state of the panel (open / closed) in the localstorage, so that when the users close it and refresh, it doesn't show up again.

## Video

https://github.com/user-attachments/assets/aae29c2e-cb00-40cf-b3fd-d32d97bfd20c

## PR checklist

Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
