### PR TITLE
Trigger `tests` workflow on merge queue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
       - trying
       - staging
       - main
+  merge_group:
 
 jobs:
   linter_check:


### PR DESCRIPTION
# Pull Request

## Related issue

As we want to move away from bors and use merge queues, we need tests to be triggered when PRs are added to the merge queue.

As this wasn't implemented, we can see that PRs pushed the merge queue failed to merge because the tests weren't trigger, e.g. #609

## What does this PR do?
- Implements `merge_group` trigger as explained in the [merge queue docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
