### PR TITLE
Improve image detection logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint .",
     "prettier-check": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
+    "test": "react-scripts test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "cy:open": "cypress open",

--- a/src/components/Results/Hit.js
+++ b/src/components/Results/Hit.js
@@ -204,7 +204,7 @@ const FieldValue = ({ hit, objectKey }) => {
   )
 }
 
-const Hit = ({ hit, imageKey }) => {
+const Hit = ({ hit }) => {
   const [displayMore, setDisplayMore] = React.useState(false)
   const [imageError, setImageError] = React.useState(false)
   const hasFields = !!hit._highlightResult
@@ -222,8 +222,8 @@ const Hit = ({ hit, imageKey }) => {
     }
   }, [])
 
-  // Determine the image source to display (prioritize auto-detected images)
-  const imageSource = imageUrls.length > 0 ? imageUrls[0] : hit[imageKey]
+  // Determine the image source to display
+  const imageSource = imageUrls.length > 0 ? imageUrls[0] : null
   const altText = hit.title || hit.name || 'Result image'
 
   // Reset image error state when image source changes

--- a/src/components/Results/Hit.js
+++ b/src/components/Results/Hit.js
@@ -20,6 +20,14 @@ const EmptyImage = styled.div`
   border-radius: 10px;
 `
 
+const StyledResultImage = styled(LazyLoadImage)`
+  max-width: 100%;
+  max-height: 264px;
+  object-fit: cover;
+  display: block;
+  border-radius: 10px;
+`
+
 const CustomCard = styled(Card)`
   display: flex;
 `
@@ -216,15 +224,15 @@ const Hit = ({ hit, imageKey }) => {
     }
   }, [])
 
+  // Determine the image source to display (prioritize auto-detected images)
+  const imageSource = imageUrls.length > 0 ? imageUrls[0] : hit[imageKey]
+  const altText = hit.title || hit.name || 'Result image'
+
   return (
     <CustomCard>
       <Box width={240} mr={4} flexShrink={0}>
-        {hit[imageKey] ? (
-          <LazyLoadImage
-            src={hit[imageKey] || null}
-            width="100%"
-            style={{ borderRadius: 10 }}
-          />
+        {imageSource ? (
+          <StyledResultImage src={imageSource} alt={altText} width="100%" />
         ) : (
           <EmptyImage />
         )}

--- a/src/components/Results/Hit.js
+++ b/src/components/Results/Hit.js
@@ -206,6 +206,7 @@ const FieldValue = ({ hit, objectKey }) => {
 
 const Hit = ({ hit, imageKey }) => {
   const [displayMore, setDisplayMore] = React.useState(false)
+  const [imageError, setImageError] = React.useState(false)
   const hasFields = !!hit._highlightResult
   const documentProperties = hasFields
     ? Object.entries(hit._highlightResult)
@@ -213,9 +214,6 @@ const Hit = ({ hit, imageKey }) => {
 
   // Extract all image URLs from the hit document
   const imageUrls = extractImageUrls(hit)
-
-  // Temporary logging for development verification (Task 1.2)
-  console.log('Image URLs found for hit:', imageUrls)
 
   useEffect(() => {
     if (!hit._highlightResult) {
@@ -228,11 +226,26 @@ const Hit = ({ hit, imageKey }) => {
   const imageSource = imageUrls.length > 0 ? imageUrls[0] : hit[imageKey]
   const altText = hit.title || hit.name || 'Result image'
 
+  // Reset image error state when image source changes
+  useEffect(() => {
+    setImageError(false)
+  }, [imageSource])
+
+  // Handle image load error
+  const handleImageError = () => {
+    setImageError(true)
+  }
+
   return (
     <CustomCard>
       <Box width={240} mr={4} flexShrink={0}>
-        {imageSource ? (
-          <StyledResultImage src={imageSource} alt={altText} width="100%" />
+        {imageSource && !imageError ? (
+          <StyledResultImage
+            src={imageSource}
+            alt={altText}
+            width="100%"
+            onError={handleImageError}
+          />
         ) : (
           <EmptyImage />
         )}

--- a/src/components/Results/Hit.js
+++ b/src/components/Results/Hit.js
@@ -11,6 +11,7 @@ import Card from 'components/Card'
 import BaseLink from 'components/Link'
 import Typography from 'components/Typography'
 import Highlight from './Highlight'
+import extractImageUrls from '../../utils/extractImageUrls'
 
 const EmptyImage = styled.div`
   width: 100%;
@@ -201,6 +202,12 @@ const Hit = ({ hit, imageKey }) => {
   const documentProperties = hasFields
     ? Object.entries(hit._highlightResult)
     : []
+
+  // Extract all image URLs from the hit document
+  const imageUrls = extractImageUrls(hit)
+
+  // Temporary logging for development verification (Task 1.2)
+  console.log('Image URLs found for hit:', imageUrls)
 
   useEffect(() => {
     if (!hit._highlightResult) {

--- a/src/components/Results/InfiniteHits.js
+++ b/src/components/Results/InfiniteHits.js
@@ -18,53 +18,16 @@ const HitsList = styled.ul`
   }
 `
 
-const isAnImage = async (elem) => {
-  // Test the standard way with regex and image extensions
-  if (
-    typeof elem === 'string' &&
-    elem.match(/^(https|http):\/\/.*(jpe?g|png|gif|webp)(\?.*)?$/gi)
-  )
-    return true
-
-  if (typeof elem === 'string' && elem.match(/^https?:\/\//)) {
-    // Tries to load an image that is a valid URL but doesn't have a correct extension
-    return new Promise((resolve) => {
-      const img = new Image()
-      img.src = elem
-      img.onload = () => resolve(true)
-      img.onerror = () => resolve(false)
-    })
-  }
-  return false
-}
-
-const findImageKey = async (array) => {
-  const promises = array.map(async (elem) => isAnImage(elem[1]))
-  const results = await Promise.all(promises)
-  const index = results.findIndex((result) => result)
-  const imageField = array[index]
-  return imageField?.[0]
-}
-
-const InfiniteHits = connectInfiniteHits(({ hits, hasMore, refineNext }) => {
-  const [imageKey, setImageKey] = React.useState(false)
-
-  React.useEffect(() => {
-    const getImageKey = async () => {
-      setImageKey(hits[0] ? await findImageKey(Object.entries(hits[0])) : null)
-    }
-    getImageKey()
-  }, [hits[0]])
+const InfiniteHits = connectInfiniteHits(({ hits, hasMore, refineNext }) => (
   // ({ hits, hasMore, refineNext, mode }) => {
-  return (
-    <div>
-      {/* {mode === 'fancy' ? ( */}
-      <HitsList>
-        {hits.map((hit, index) => (
-          <Hit key={index} hit={hit} imageKey={imageKey} />
-        ))}
-      </HitsList>
-      {/* ) : (
+  <div>
+    {/* {mode === 'fancy' ? ( */}
+    <HitsList>
+      {hits.map((hit, index) => (
+        <Hit key={index} hit={hit} />
+      ))}
+    </HitsList>
+    {/* ) : (
         <Card style={{ fontSize: 14, minHeight: 320 }}>
           <ReactJson
             src={hits}
@@ -77,19 +40,18 @@ const InfiniteHits = connectInfiniteHits(({ hits, hasMore, refineNext }) => {
           />
         </Card>
       )} */}
-      {hasMore && (
-        <Button
-          size="small"
-          variant="bordered"
-          onClick={refineNext}
-          style={{ margin: '0 auto', marginTop: 32 }}
-        >
-          Load more
-        </Button>
-      )}
-      <ScrollToTop />
-    </div>
-  )
-})
+    {hasMore && (
+      <Button
+        size="small"
+        variant="bordered"
+        onClick={refineNext}
+        style={{ margin: '0 auto', marginTop: 32 }}
+      >
+        Load more
+      </Button>
+    )}
+    <ScrollToTop />
+  </div>
+))
 
 export default InfiniteHits

--- a/src/utils/extractImageUrls.js
+++ b/src/utils/extractImageUrls.js
@@ -1,0 +1,63 @@
+/**
+ * Extracts all potential image URLs from a JSON document object.
+ *
+ * @param {any} documentObject - The JSON object to search for image URLs
+ * @returns {string[]} Array of unique image URLs found in the document
+ */
+export default function extractImageUrls(documentObject) {
+  // Handle null, undefined, or non-object inputs
+  if (!documentObject || typeof documentObject !== 'object') {
+    return []
+  }
+
+  const imageUrls = new Set() // Use Set to automatically handle uniqueness
+
+  // Regular expression patterns for image URLs
+  const imageExtensionPattern = /\.(png|jpg|jpeg|gif|webp|svg)(\?.*)?$/i
+  const dataImagePattern = /^data:image\//i
+
+  /**
+   * Recursively traverses an object to find image URLs
+   * @param {any} obj - Current object/value being processed
+   */
+  function traverse(obj) {
+    // Handle null or undefined
+    if (obj === null || obj === undefined) {
+      return
+    }
+
+    // If it's a string, check if it's an image URL
+    if (typeof obj === 'string') {
+      const trimmedStr = obj.trim()
+
+      // Check for common image file extensions
+      if (imageExtensionPattern.test(trimmedStr)) {
+        imageUrls.add(trimmedStr)
+      }
+      // Check for data:image/ URLs (base64 encoded images)
+      else if (dataImagePattern.test(trimmedStr)) {
+        imageUrls.add(trimmedStr)
+      }
+      return
+    }
+
+    // If it's an array, traverse each element
+    if (Array.isArray(obj)) {
+      obj.forEach((item) => traverse(item))
+      return
+    }
+
+    // If it's an object, traverse each property value
+    if (typeof obj === 'object') {
+      Object.values(obj).forEach((value) => traverse(value))
+    }
+
+    // For primitive types (number, boolean, etc.), do nothing
+  }
+
+  // Start the traversal
+  traverse(documentObject)
+
+  // Convert Set back to Array and return
+  return Array.from(imageUrls)
+}

--- a/src/utils/extractImageUrls.js
+++ b/src/utils/extractImageUrls.js
@@ -1,3 +1,5 @@
+const MAX_DEPTH = 10
+
 /**
  * Extracts all potential image URLs from a JSON document object.
  *
@@ -19,8 +21,14 @@ export default function extractImageUrls(documentObject) {
   /**
    * Recursively traverses an object to find image URLs
    * @param {any} obj - Current object/value being processed
+   * @param {number} depth - Current depth in the object hierarchy
    */
-  function traverse(obj) {
+  function traverse(obj, depth = 0) {
+    // Stop traversal if we've reached the maximum depth
+    if (depth >= MAX_DEPTH) {
+      return
+    }
+
     // Handle null or undefined
     if (obj === null || obj === undefined) {
       return
@@ -43,13 +51,13 @@ export default function extractImageUrls(documentObject) {
 
     // If it's an array, traverse each element
     if (Array.isArray(obj)) {
-      obj.forEach((item) => traverse(item))
+      obj.forEach((item) => traverse(item, depth + 1))
       return
     }
 
     // If it's an object, traverse each property value
     if (typeof obj === 'object') {
-      Object.values(obj).forEach((value) => traverse(value))
+      Object.values(obj).forEach((value) => traverse(value, depth + 1))
     }
 
     // For primitive types (number, boolean, etc.), do nothing

--- a/src/utils/extractImageUrls.test.js
+++ b/src/utils/extractImageUrls.test.js
@@ -1,0 +1,194 @@
+import extractImageUrls from './extractImageUrls'
+
+describe('extractImageUrls', () => {
+  test('should extract image URL from simple object', () => {
+    const input = { image: 'http://example.com/image.png' }
+    const result = extractImageUrls(input)
+    expect(result).toEqual(['http://example.com/image.png'])
+  })
+
+  test('should extract image URLs from nested object', () => {
+    const input = {
+      details: {
+        mainImage: 'http://example.com/photo.jpg',
+        description: 'A beautiful photo',
+      },
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual(['http://example.com/photo.jpg'])
+  })
+
+  test('should extract image URLs from array', () => {
+    const input = {
+      gallery: ['img1.gif', 'http://example.com/img2.webp'],
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual(['img1.gif', 'http://example.com/img2.webp'])
+  })
+
+  test('should handle mixed content including non-URL strings', () => {
+    const input = {
+      title: 'My Article',
+      content: 'This is some text content',
+      image: 'http://example.com/article.png',
+      author: 'John Doe',
+      tags: ['tech', 'programming'],
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual(['http://example.com/article.png'])
+  })
+
+  test('should extract data:image URLs', () => {
+    const input = {
+      avatar:
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+      name: 'User',
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual([
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+    ])
+  })
+
+  test('should return unique URLs when duplicates exist', () => {
+    const input = {
+      image1: 'http://example.com/duplicate.jpg',
+      image2: 'http://example.com/duplicate.jpg',
+      gallery: [
+        'http://example.com/duplicate.jpg',
+        'http://example.com/unique.png',
+      ],
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual([
+      'http://example.com/duplicate.jpg',
+      'http://example.com/unique.png',
+    ])
+  })
+
+  test('should return empty array when no image URLs found', () => {
+    const input = {
+      title: 'Article Title',
+      content: 'Some text content',
+      author: 'John Doe',
+      tags: ['tech', 'programming'],
+      metadata: {
+        created: '2023-01-01',
+        views: 100,
+      },
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual([])
+  })
+
+  test('should handle null input gracefully', () => {
+    const result = extractImageUrls(null)
+    expect(result).toEqual([])
+  })
+
+  test('should handle undefined input gracefully', () => {
+    const result = extractImageUrls(undefined)
+    expect(result).toEqual([])
+  })
+
+  test('should handle non-object input gracefully', () => {
+    expect(extractImageUrls('string')).toEqual([])
+    expect(extractImageUrls(123)).toEqual([])
+    expect(extractImageUrls(true)).toEqual([])
+  })
+
+  test('should extract multiple different image formats', () => {
+    const input = {
+      images: {
+        png: 'http://example.com/image.png',
+        jpg: 'http://example.com/photo.jpg',
+        jpeg: 'http://example.com/picture.jpeg',
+        gif: 'http://example.com/animation.gif',
+        webp: 'http://example.com/modern.webp',
+        svg: 'http://example.com/vector.svg',
+      },
+    }
+    const result = extractImageUrls(input)
+    expect(result).toHaveLength(6)
+    expect(result).toContain('http://example.com/image.png')
+    expect(result).toContain('http://example.com/photo.jpg')
+    expect(result).toContain('http://example.com/picture.jpeg')
+    expect(result).toContain('http://example.com/animation.gif')
+    expect(result).toContain('http://example.com/modern.webp')
+    expect(result).toContain('http://example.com/vector.svg')
+  })
+
+  test('should handle URLs with query parameters', () => {
+    const input = {
+      thumbnail: 'http://example.com/thumb.jpg?size=small&quality=80',
+      fullsize: 'http://example.com/full.png?width=1920&height=1080',
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual([
+      'http://example.com/thumb.jpg?size=small&quality=80',
+      'http://example.com/full.png?width=1920&height=1080',
+    ])
+  })
+
+  test('should handle deeply nested objects', () => {
+    const input = {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              deepImage: 'http://example.com/deep.jpg',
+            },
+          },
+        },
+      },
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual(['http://example.com/deep.jpg'])
+  })
+
+  test('should handle arrays within nested objects', () => {
+    const input = {
+      article: {
+        content: {
+          sections: [
+            {
+              type: 'text',
+              value: 'Some text',
+            },
+            {
+              type: 'image',
+              value: 'http://example.com/section1.png',
+            },
+            {
+              type: 'gallery',
+              images: [
+                'http://example.com/gallery1.jpg',
+                'http://example.com/gallery2.jpg',
+              ],
+            },
+          ],
+        },
+      },
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual([
+      'http://example.com/section1.png',
+      'http://example.com/gallery1.jpg',
+      'http://example.com/gallery2.jpg',
+    ])
+  })
+
+  test('should handle case-insensitive file extensions', () => {
+    const input = {
+      upperCase: 'http://example.com/IMAGE.PNG',
+      mixedCase: 'http://example.com/Photo.JpG',
+      lowerCase: 'http://example.com/picture.gif',
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual([
+      'http://example.com/IMAGE.PNG',
+      'http://example.com/Photo.JpG',
+      'http://example.com/picture.gif',
+    ])
+  })
+})

--- a/src/utils/extractImageUrls.test.js
+++ b/src/utils/extractImageUrls.test.js
@@ -191,4 +191,31 @@ describe('extractImageUrls', () => {
       'http://example.com/picture.gif',
     ])
   })
+
+  test('should respect MAX_DEPTH limit and stop traversal at maximum depth', () => {
+    const input = {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              level5: {
+                level6: {
+                  level7: {
+                    level8: {
+                      level9Image: 'http://example.com/level9.jpg',
+                      level9: {
+                        level10Image: 'http://example.com/level10.jpg',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+    const result = extractImageUrls(input)
+    expect(result).toEqual(['http://example.com/level9.jpg'])
+  })
 })


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #613 

## What does this PR do?
- Make image field detection logic recursive to find nested image fields
- Move image detection logic at the hit level - to handle documents with different structures
- Add relevant unit tests

The `extractImageUrls` function collects all image URLs in the document, which can be useful for later allowing the user to see different images (#616)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
