### PR TITLE
fix(newsletter): include hubspotutk (hutk) in HubSpot form submissions

### DIFF
--- a/src/hooks/useNewsletter.js
+++ b/src/hooks/useNewsletter.js
@@ -1,4 +1,5 @@
 import version from '../version/version'
+import getCookie from '../utils/getCookie'
 
 const PORTAL_ID = import.meta.env.VITE_HUBSPOT_PORTAL_ID
 const FORM_GUID = import.meta.env.VITE_HUBSPOT_FORM_GUID
@@ -6,6 +7,22 @@ const FORM_GUID = import.meta.env.VITE_HUBSPOT_FORM_GUID
 const PAGE_NAME = import.meta.env.DEV
   ? `Mini-dashboard (dev)`
   : `Mini-dashboard v${version}`
+
+function getContext({ pageName }) {
+  const context = {
+    pageName,
+    pageUri: typeof window !== 'undefined' ? window.location.href : undefined,
+  }
+
+  // The `hubspotutk` cookie is set by HubSpot's tracking code and ties this
+  // submission to the visitor's tracked activity and the right contact record.
+  // Only include `hutk` when the cookie actually exists — HubSpot rejects an
+  // empty value with INVALID_HUTK, so a cookieless submission must omit it.
+  const hutk = getCookie('hubspotutk')
+  if (hutk) context.hutk = hutk
+
+  return context
+}
 
 function getBody({ email, pageName }) {
   return {
@@ -16,9 +33,7 @@ function getBody({ email, pageName }) {
         value: email,
       },
     ],
-    context: {
-      pageName,
-    },
+    context: getContext({ pageName }),
     legalConsentOptions: {
       consent: {
         consentToProcess: true,

--- a/src/utils/getCookie.js
+++ b/src/utils/getCookie.js
@@ -1,0 +1,9 @@
+const getCookie = (name) => {
+  if (typeof document === 'undefined') return undefined
+  const value = `; ${document.cookie}`
+  const parts = value.split(`; ${name}=`)
+  if (parts.length === 2) return parts.pop().split(';').shift()
+  return undefined
+}
+
+export default getCookie


### PR DESCRIPTION
## Problem

Newsletter submissions from the mini-dashboard are sent to the HubSpot Forms API **without the visitor's HubSpot tracking token (`hutk`)**. In HubSpot this causes:

- Submissions can't be linked to the correct contact record ("No contact record").
- No IP address is captured, which breaks form analytics.
- Because HubSpot can't dedupe/attribute properly, many submissions collapse onto a single existing contact instead of the real user.

<img width="2834" height="1532" alt="image (34)" src="https://github.com/user-attachments/assets/56899347-cece-4324-b496-db6cd6f92fd1" />

<img width="2834" height="1532" alt="image (35)" src="https://github.com/user-attachments/assets/955b8376-f12d-44e2-9d54-6c9ad761d183" />


## Root cause

HubSpot uses the `hutk` value — the `hubspotutk` cookie set in the visitor's browser by the HubSpot tracking code — to tie a Forms API submission to that browser's tracked activity and the right contact. The current integration in `src/hooks/useNewsletter.js` never read that cookie, so it was never included in the request payload.

## Fix

- Add a small `getCookie` util (`src/utils/getCookie.js`).
- In `useNewsletter`, build the Forms API `context` object from the browser: read the `hubspotutk` cookie and include it as `hutk`, plus `pageUri` from `window.location.href` (`pageName` was already sent).
- **`hutk` is only included when the cookie actually exists.** HubSpot rejects an empty `hutk` with an `INVALID_HUTK` error, so cookieless submissions omit the field entirely and still succeed.
- `ipAddress` is intentionally left out — it can't be read reliably client-side. `hutk` is the priority for contact linkage.

## Reviewer caveat

This only works if the `hubspotutk` cookie actually exists in the browser at submit time. That requires the **HubSpot tracking code to be loaded on the page where the mini-dashboard runs, on the same domain the cookie is scoped to**. If the tracking script isn't present on that page, this PR alone won't fully fix the attribution issue — that needs to be confirmed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newsletter form submissions now include more page context information when available, helping improve submission tracking and handling.
  * Cookies are now used when present to support more complete newsletter request details.

* **Bug Fixes**
  * Improved behavior in browser and non-browser environments so newsletter submission data is only added when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->